### PR TITLE
組方向変更命令の実行可能条件

### DIFF
--- a/source/texk/ptexenc/ChangeLog
+++ b/source/texk/ptexenc/ChangeLog
@@ -1,7 +1,7 @@
 2017-09-09  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
 
 	* ptexenc.c, ptexenc/ptexenc.h: Add a new function setstdinenc() for the
-	primitive \epTeXinputencoding in e-(u)pTeX. (from N. Abe).
+	primitive \epTeXinputencoding in e-(u)pTeX.
 
 2017-03-18  Karl Berry  <karl@tug.org>
 

--- a/source/texk/ptexenc/ChangeLog
+++ b/source/texk/ptexenc/ChangeLog
@@ -1,3 +1,8 @@
+2017-09-09  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
+
+	* ptexenc.c, ptexenc/ptexenc.h: Add a new function setstdinenc() for the
+	primitive \epTeXinputencoding in e-(u)pTeX. (from N. Abe).
+
 2017-03-18  Karl Berry  <karl@tug.org>
 
 	* version.ac (ptexenc_version): 1.3.5dev => 1.3.5 for TL17.

--- a/source/texk/ptexenc/ptexenc.c
+++ b/source/texk/ptexenc/ptexenc.c
@@ -840,12 +840,14 @@ long input_line2(FILE *fp, unsigned char *buff, long pos,
     return last;
 }
 
+// set encode of stdin if fp = NULL
 boolean setinfileenc(FILE *fp, const char *str)
 {
     int enc;
     enc = string_to_enc(str);
     if (enc < 0) return false;
-    infile_enc[fileno(fp)] = enc;
+    if (fp == NULL) infile_enc[fileno(stdin)] = enc;
+    else infile_enc[fileno(fp)] = enc;
     return true;
 }
 

--- a/source/texk/ptexenc/ptexenc.c
+++ b/source/texk/ptexenc/ptexenc.c
@@ -846,8 +846,16 @@ boolean setinfileenc(FILE *fp, const char *str)
     int enc;
     enc = string_to_enc(str);
     if (enc < 0) return false;
-    if (fp == NULL) infile_enc[fileno(stdin)] = enc;
-    else infile_enc[fileno(fp)] = enc;
+    infile_enc[fileno(fp)] = enc;
+    return true;
+}
+
+boolean setstdinenc(const char *str)
+{
+    int enc;
+    enc = string_to_enc(str);
+    if (enc < 0) return false;
+    infile_enc[fileno(stdin)] = enc;
     return true;
 }
 

--- a/source/texk/ptexenc/ptexenc/ptexenc.h
+++ b/source/texk/ptexenc/ptexenc/ptexenc.h
@@ -83,6 +83,7 @@ extern PTENCDLL long input_line2(FILE *fp, unsigned char *buff, long pos,
 
 /* set current encoding */
 extern PTENCDLL boolean setinfileenc(FILE *fp, const char *str);
+extern PTENCDLL boolean setstdinenc(const char *str);
 
 #ifdef WIN32
 extern PTENCDLL void clear_infile_enc(FILE *fp);

--- a/source/texk/web2c/eptexdir/ChangeLog
+++ b/source/texk/web2c/eptexdir/ChangeLog
@@ -1,3 +1,13 @@
+2017-09-09  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
+	and Noriyuki Abe  <abenori@math.sci.hokudai.ac.jp>
+
+	* eptex.ech: \epTeXinputencoding works also with the terminal.
+	* eptex.defines: Add a new function setstdinenc().
+
+2017-09-06  Noriyuki Abe  <abenori@math.sci.hokudai.ac.jp>
+
+	* eptex.ech: fix a bug in \epTeXinputencoding.
+
 2017-04-24  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
 
 	* eptex.ech, etex.ch1, euptex.ch0, pdfutils.ch:

--- a/source/texk/web2c/eptexdir/eptex.defines
+++ b/source/texk/web2c/eptexdir/eptex.defines
@@ -20,6 +20,7 @@
 @define function inputline2 ();
 
 @define function setinfileenc ();
+@define function setstdinenc ();
 
 @define function fromJIS ();
 @define function fromEUC ();

--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -355,8 +355,11 @@ begin
       end
     end
   else if name>19 then j:=index else j:=-(name+1);
-  if j>=0 then begin
-    if setinfileenc(input_file[j],stringcast(name_of_file+1)) = false then
+  if (j>=0) or (j=-1) or (j=-18) then begin
+    k:=true;
+    if j>= 0 then k:=setinfileenc(input_file[j],stringcast(name_of_file+1))
+    else k:=setinfileenc(0,stringcast(name_of_file+1));
+    if k = false then
       begin wlog_cr;
       wlog('Unknown encoding `');
       fputs(stringcast(name_of_file + 1), log_file);
@@ -368,8 +371,7 @@ begin
     print_ln;
     print_nl("Warning: \epTeXinputencoding is ignored, since I am current reading");
     print_nl("from ");
-    if (j=0)or(j=17) then print("the terminal.") 
-    else if j>=18 then print("a pseudo file created by \scantokens.")
+    if j>=18 then print("a pseudo file created by \scantokens.")
     else begin print("input stream "); print_int(j); print("."); end;
     end_diagnostic(true);
     end

--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -339,18 +339,44 @@ epTeX_input_encoding_code:@<Implement \.{\\epTeXinputencoding}@>;
 @x
 @ @<Finish the extensions@>=
 @y
-@ @<Implement \.{\\epTeXinputencoding}@>=
-  begin
-    scan_file_name;
-    pack_cur_name;
-    if setinfileenc(input_file[in_open],stringcast(name_of_file+1)) = false then
-    begin
-      wlog_cr;
+@ @<Declare procedures needed in |do_ext...@>=
+procedure eptex_set_input_encoding;
+var j,k:integer;
+begin
+  scan_file_name;
+  pack_cur_name;
+  if state=token_list then
+    begin k:=input_ptr-1; j:=-1;
+    while k>=0 do
+      begin if input_stack[k].state_field=token_list then decr(k)
+      else if input_stack[k].name_field>19 then 
+        begin j:=input_stack[k].index_field; k:=-1; end
+      else begin j:=-(name+1); k:=-1; end
+      end
+    end
+  else if name>19 then j:=index else j:=-(name+1);
+  if j>=0 then begin
+    if setinfileenc(input_file[j],stringcast(name_of_file+1)) = false then
+      begin wlog_cr;
       wlog('Unknown encoding `');
       fputs(stringcast(name_of_file + 1), log_file);
       wlog('''');
+      end
     end
-  end
+  else 
+    begin begin_diagnostic; j:=-j-1;
+    print_ln;
+    print_nl("Warning: \epTeXinputencoding is ignored, since I am current reading");
+    print_nl("from ");
+    if (j=0)or(j=17) then print("the terminal.") 
+    else if j>=18 then print("a pseudo file created by \scantokens.")
+    else begin print("input stream "); print_int(j); print("."); end;
+    end_diagnostic(true);
+    end
+end;
+
+@ @<Implement \.{\\epTeXinputencoding}@>=
+eptex_set_input_encoding
 
 @ @<Finish the extensions@>=
 @z

--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -358,12 +358,11 @@ begin
   if (j>=0) or (j=-1) or (j=-18) then begin
     k:=true;
     if j>= 0 then k:=setinfileenc(input_file[j],stringcast(name_of_file+1))
-    else k:=setinfileenc(0,stringcast(name_of_file+1));
+    else k:=setstdinenc(stringcast(name_of_file+1));
     if k = false then
-      begin wlog_cr;
-      wlog('Unknown encoding `');
-      fputs(stringcast(name_of_file + 1), log_file);
-      wlog('''');
+      begin begin_diagnostic;
+      print_nl("Unknown encoding `"); print(stringcast(name_of_file + 1));
+      print("'"); end_diagnostic(false);
       end
     end
   else 
@@ -373,7 +372,7 @@ begin
     print_nl("from ");
     if j>=18 then print("a pseudo file created by \scantokens.")
     else begin print("input stream "); print_int(j); print("."); end;
-    end_diagnostic(true);
+    end_diagnostic(false);
     end
 end;
 

--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -349,7 +349,7 @@ begin
     begin k:=input_ptr-1; j:=-1;
     while k>=0 do
       begin if input_stack[k].state_field=token_list then decr(k)
-      else if input_stack[k].name_field>19 then 
+      else if input_stack[k].name_field>19 then
         begin j:=input_stack[k].index_field; k:=-1; end
       else begin j:=-(name+1); k:=-1; end
       end
@@ -361,11 +361,17 @@ begin
     else k:=setstdinenc(stringcast(name_of_file+1));
     if k = false then
       begin begin_diagnostic;
-      print_nl("Unknown encoding `"); print(stringcast(name_of_file + 1));
+      print_nl("Unknown encoding `");
+      case selector of
+      term_and_log: begin wterm(stringcast(name_of_file + 1));
+	wlog(stringcast(name_of_file + 1)); end;
+      log_only:  wlog(stringcast(name_of_file + 1));
+      term_only: wterm(stringcast(name_of_file + 1));
+      endcases;
       print("'"); end_diagnostic(false);
       end
     end
-  else 
+  else
     begin begin_diagnostic; j:=-j-1;
     print_ln;
     print_nl("Warning: \epTeXinputencoding is ignored, since I am current reading");

--- a/source/texk/web2c/euptexdir/ChangeLog
+++ b/source/texk/web2c/euptexdir/ChangeLog
@@ -1,3 +1,7 @@
+2017-09-09  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
+
+	* euptex.defines: Add a new function setstdinenc().
+
 2017-04-24  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
 
 	* euptex.ch0: Adapt to changes in ptexdir/ptex-base.ch (p\TeX -> \pTeX).

--- a/source/texk/web2c/euptexdir/euptex.defines
+++ b/source/texk/web2c/euptexdir/euptex.defines
@@ -25,6 +25,7 @@
 @define function inputline2 ();
 
 @define function setinfileenc ();
+@define function setstdinenc ();
 
 @define function fromJIS ();
 @define function fromEUC ();


### PR DESCRIPTION
#21 で議論していますが，\tate, \yoko といった組方向変更命令が不自然な場所でも実行できてしまうことに対処したものです．
 * 非制限水平モード（行分割される段落），数式モード（文中，別行問わず）での実行を禁止しています．
 * 外部垂直モードの場合は，次の2点が同時に満たされる場合のみ実行可能としました：
   * current page の中身には box, rule, insertion はなく，mark, whatsit のみ (page_contents=empty)
   * recent contribution の中身にも box, rule, insertion はない（ページビルダーの過程で，先頭にある glue, kern, penalty は破棄されるので無視して良い）

現在の縦組クラスは `\AtBeginDcoument` 内で組方向を縦組にしていますが，それを変更する必要はないはずです．
