### PR TITLE
禁則テーブル，\inhibitxspcode 情報テーブルからのエントリ削除

### DIFF
--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -6292,7 +6292,10 @@ assign_inhibit_xsp_code:
 begin p:=cur_chr; scan_int; n:=cur_val; scan_optional_equals; scan_int;
 if is_char_kanji(n) then
   begin j:=get_inhibit_pos(tokanji(n),new_pos);
-  if j=no_entry then
+  if (j<>no_entry)and(cur_val>inhibit_after) then 
+    begin n:=0; cur_val:=0 end
+    { remove the entry from inhibit table }
+  else if j=no_entry then
     begin print_err("Inhibit table is full!!");
     help1("I'm skipping this control sequences.");@/
     error; return;
@@ -6366,17 +6369,21 @@ assign_kinsoku:
 begin p:=cur_chr; scan_int; n:=cur_val; scan_optional_equals; scan_int;
 if is_char_ascii(n) or is_char_kanji(n) then
   begin j:=get_kinsoku_pos(tokanji(n),new_pos);
-  if j=no_entry then
-    begin print_err("KINSOKU table is full!!");
-    help1("I'm skipping this control sequences.");@/
-    error; return;
-    end;
-  if (p=pre_break_penalty_code)or(p=post_break_penalty_code) then
-    begin define(kinsoku_base+j,p,tokanji(n));
-    word_define(kinsoku_penalty_base+j,cur_val);
-    end
-  else confusion("kinsoku");
+  if (j<>no_entry)and(cur_val=0) then define(kinsoku_base+j,0,0)
+    { remove the entry from KINSOKU table }
+  else begin
+    if j=no_entry then
+      begin print_err("KINSOKU table is full!!");
+      help1("I'm skipping this control sequences.");@/
+      error; return;
+      end;
+    if (p=pre_break_penalty_code)or(p=post_break_penalty_code) then
+      begin define(kinsoku_base+j,p,tokanji(n));
+      word_define(kinsoku_penalty_base+j,cur_val);
+      end
+    else confusion("kinsoku");
 @:this can't happen kinsoku}{\quad kinsoku@>
+    end
   end
 else
   begin print_err("Invalid KANJI code for ");
@@ -6725,7 +6732,7 @@ else
 
 @ @<Insert a space after the |last_char|@>=
 if type(last_char)=math_node then
-  begin ax:=qo("0"); 
+  begin ax:=qo("0");
   if auto_xsp_code(ax)>=2 then
     insert_skip:=after_schar else insert_skip:=no_skip;
   end

--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -6295,13 +6295,10 @@ if is_char_kanji(n) then
   if (j<>no_entry)and(cur_val>inhibit_after)and(global or cur_level=level_one) then
     begin n:=0; cur_val:=0 end
     { remove the entry from inhibit table }
-  else if j=no_entry then begin
-    if (cur_val<=inhibit_after) and not(cur_level=level_one or not global) then
-      begin print_err("Inhibit table is full!!");
-      help1("I'm skipping this control sequences.");@/
-      error; end;
-    return;
-    end;
+  else if j=no_entry then
+    begin print_err("Inhibit table is full!!");
+    help1("I'm skipping this control sequences.");@/
+    error; return; end;
   define(inhibit_xsp_code_base+j,cur_val,n);
   end
 else
@@ -6375,12 +6372,9 @@ if is_char_ascii(n) or is_char_kanji(n) then
     define(kinsoku_base+j,0,0) { remove the entry from KINSOKU table }
   else begin
     if j=no_entry then begin
-      if (cur_val<>0) and not(cur_level=level_one or not global) then
-        begin print_err("KINSOKU table is full!!");
-        help1("I'm skipping this control sequences.");@/
-        error; end;
-      return;
-      end;
+      print_err("KINSOKU table is full!!");
+      help1("I'm skipping this control sequences.");@/
+      error; return; end;
     if (p=pre_break_penalty_code)or(p=post_break_penalty_code) then
       begin define(kinsoku_base+j,p,tokanji(n));
       word_define(kinsoku_penalty_base+j,cur_val);

--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -6292,14 +6292,16 @@ assign_inhibit_xsp_code:
 begin p:=cur_chr; scan_int; n:=cur_val; scan_optional_equals; scan_int;
 if is_char_kanji(n) then
   begin j:=get_inhibit_pos(tokanji(n),new_pos);
-  if (j<>no_entry)and(cur_val>inhibit_after) then 
+  if (j<>no_entry)and(cur_val>inhibit_after)and(global or cur_level=level_one) then
     begin n:=0; cur_val:=0 end
     { remove the entry from inhibit table }
-  else if j=no_entry then
-    begin print_err("Inhibit table is full!!");
-    help1("I'm skipping this control sequences.");@/
-    error; return;
-  end;
+  else if j=no_entry then begin
+    if (cur_val<=inhibit_after) and not(cur_level=level_one or not global) then
+      begin print_err("Inhibit table is full!!");
+      help1("I'm skipping this control sequences.");@/
+      error; end;
+    return;
+    end;
   define(inhibit_xsp_code_base+j,cur_val,n);
   end
 else
@@ -6369,13 +6371,15 @@ assign_kinsoku:
 begin p:=cur_chr; scan_int; n:=cur_val; scan_optional_equals; scan_int;
 if is_char_ascii(n) or is_char_kanji(n) then
   begin j:=get_kinsoku_pos(tokanji(n),new_pos);
-  if (j<>no_entry)and(cur_val=0) then define(kinsoku_base+j,0,0)
-    { remove the entry from KINSOKU table }
+  if (j<>no_entry)and(cur_val=0)and(global or cur_level=level_one) then
+    define(kinsoku_base+j,0,0) { remove the entry from KINSOKU table }
   else begin
-    if j=no_entry then
-      begin print_err("KINSOKU table is full!!");
-      help1("I'm skipping this control sequences.");@/
-      error; return;
+    if j=no_entry then begin
+      if (cur_val<>0) and not(cur_level=level_one or not global) then
+        begin print_err("KINSOKU table is full!!");
+        help1("I'm skipping this control sequences.");@/
+        error; end;
+      return;
       end;
     if (p=pre_break_penalty_code)or(p=post_break_penalty_code) then
       begin define(kinsoku_base+j,p,tokanji(n));

--- a/source/texk/web2c/ptexdir/tests/kinsoku_table.tex
+++ b/source/texk/web2c/ptexdir/tests/kinsoku_table.tex
@@ -1,0 +1,48 @@
+%#!uptex
+\newcount\fuga\newcount\dflt
+\iffalse
+  \global\let\prebreakpenalty=\inhibitxspcode
+  \fuga="30D3 \dflt=3
+\else
+  \fuga="3090 \dflt=0
+\fi
+
+\scrollmode
+\newcount\hoge\hoge="3000
+\loop\ifnum\hoge<\fuga
+  \message{\the\hoge}\prebreakpenalty\hoge=2
+  \advance\hoge 1\relax \repeat
+
+\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% 2, D
+{
+  \prebreakpenalty"3001=\dflt\relax
+  \prebreakpenalty"5000=\dflt\relax % no error
+  \global\prebreakpenalty"4000=1\relax% error
+\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% D, D
+}
+
+\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% 2, D
+
+{
+  \global\prebreakpenalty"3001=\dflt\relax
+  \prebreakpenalty"4000=1\relax% no error
+\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% D, 1
+}
+\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% D, D
+
+\prebreakpenalty"4000=1\relax% no error
+
+\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000,
+  \the\prebreakpenalty"3549>}% D, 1, D
+
+\prebreakpenalty"4000=\dflt\relax
+
+\prebreakpenalty"3549=1\relax% no error
+\prebreakpenalty"3548=\dflt\relax% no error
+
+\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000,
+  \the\prebreakpenalty"3549>}% D, D, 1
+
+
+\end
+

--- a/source/texk/web2c/ptexdir/tests/kinsoku_table.tex
+++ b/source/texk/web2c/ptexdir/tests/kinsoku_table.tex
@@ -16,7 +16,6 @@
 \message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% 2, D
 {
   \prebreakpenalty"3001=\dflt\relax
-  \prebreakpenalty"5000=\dflt\relax % no error
   \global\prebreakpenalty"4000=1\relax% error
 \message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% D, D
 }
@@ -38,7 +37,6 @@
 \prebreakpenalty"4000=\dflt\relax
 
 \prebreakpenalty"3549=1\relax% no error
-\prebreakpenalty"3548=\dflt\relax% no error
 
 \message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000,
   \the\prebreakpenalty"3549>}% D, D, 1


### PR DESCRIPTION
pTeX では \prebreakpenalty, \postbreakpenalty の情報を禁則テーブルに，また \inhibitxspcode の情報を専用テーブルに格納していますが，これらはどちらも 256 文字の領域しかありません．

実用上は困らないと思いますが，「一旦テーブルに追加されるとそこから削除されることはない」という仕様が気になったので，デフォルト値（禁則ペナルティの場合は 0，\inhibitxspcode の場合は 3）を設定した場合には該当するテーブルからエントリを削除するようにしてみました．

なお，ptex-manual のコミット texjporg/ptex-manual@8f8c0ab0a0ca9fdc26702178c8a9b49d97506d37 では，本プルリクの内容も含めた記述になっています．