### PR TITLE
ペナルティの合算処理，隣接するペナルティ

### DIFF
--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -6409,7 +6409,13 @@ begin kp:=get_kinsoku_pos(cx,cur_pos);
 if kp<>no_entry then if kinsoku_penalty(kp)<>0 then
   begin if kinsoku_type(kp)=pre_break_penalty_code then
     begin if not is_char_node(cur_q)and(type(cur_q)=penalty_node) then
-      penalty(cur_q):=penalty(cur_q)+kinsoku_penalty(kp)
+      if (penalty(cur_q)>-10000)and(penalty(cur_q)<10000) then
+        if (kinsoku_penalty(kp)>=10000) then penalty(cur_q):=10000
+        else if (kinsoku_penalty(kp)<=-10000) then penalty(cur_q):=-10000
+        else begin penalty(cur_q):=penalty(cur_q)+kinsoku_penalty(kp);
+          if (penalty(cur_q)>=10000) then penalty(cur_q):=10000
+          else if (penalty(cur_q)<=-10000) then penalty(cur_q):=-10000;
+          end
     else
       begin main_p:=link(cur_q); link(cur_q):=new_penalty(kinsoku_penalty(kp));
       subtype(link(cur_q)):=kinsoku_pena; link(link(cur_q)):=main_p;

--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -6404,19 +6404,25 @@ end
 
 @ Following codes are used in |main_control|.
 
-@<Insert kinsoku penalty@>=
+@<Declare act...@>=
+procedure add_kinsoku_penalty(kp:integer;n:pointer);
+begin if (penalty(n)>-inf_bad)and(penalty(n)<inf_bad) then begin
+  if kp>=inf_bad then penalty(n):=inf_bad
+  else if kp<=-inf_bad then penalty(n):=-inf_bad
+  else
+    begin penalty(n):=penalty(n)+kp;
+    if penalty(n)>=inf_bad then penalty(n):=inf_bad
+    else if penalty(n)<=-inf_bad then penalty(n):=-inf_bad;
+    end;
+  end;
+end;
+
+@ @<Insert kinsoku penalty@>=
 begin kp:=get_kinsoku_pos(cx,cur_pos);
 if kp<>no_entry then if kinsoku_penalty(kp)<>0 then
   begin if kinsoku_type(kp)=pre_break_penalty_code then
     begin if not is_char_node(cur_q)and(type(cur_q)=penalty_node) then
-      begin if (penalty(cur_q)>-10000)and(penalty(cur_q)<10000) then
-        if (kinsoku_penalty(kp)>=10000) then penalty(cur_q):=10000
-        else if (kinsoku_penalty(kp)<=-10000) then penalty(cur_q):=-10000
-        else begin penalty(cur_q):=penalty(cur_q)+kinsoku_penalty(kp);
-          if (penalty(cur_q)>=10000) then penalty(cur_q):=10000
-          else if (penalty(cur_q)<=-10000) then penalty(cur_q):=-10000;
-          end
-      end
+      add_kinsoku_penalty(kinsoku_penalty(kp), cur_q)
     else
       begin main_p:=link(cur_q); link(cur_q):=new_penalty(kinsoku_penalty(kp));
       subtype(link(cur_q)):=kinsoku_pena; link(link(cur_q)):=main_p;
@@ -6434,14 +6440,7 @@ begin kp:=get_kinsoku_pos(cur_chr,cur_pos);
 if kp<>no_entry then if kinsoku_penalty(kp)<>0 then
   begin if kinsoku_type(kp)=pre_break_penalty_code then
     if not is_char_node(tail)and(type(tail)=penalty_node) then
-      begin if (penalty(tail)>-10000)and(penalty(tail)<10000) then
-        if (kinsoku_penalty(kp)>=10000) then penalty(tail):=10000
-        else if (kinsoku_penalty(kp)<=-10000) then penalty(tail):=-10000
-        else begin penalty(tail):=penalty(tail)+kinsoku_penalty(kp);
-          if (penalty(tail)>=10000) then penalty(tail):=10000
-          else if (penalty(tail)<=-10000) then penalty(tail):=-10000;
-          end
-      end
+      add_kinsoku_penalty(kinsoku_penalty(kp), tail)
     else
       begin tail_append(new_penalty(kinsoku_penalty(kp)));
       subtype(tail):=kinsoku_pena;

--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -6409,13 +6409,14 @@ begin kp:=get_kinsoku_pos(cx,cur_pos);
 if kp<>no_entry then if kinsoku_penalty(kp)<>0 then
   begin if kinsoku_type(kp)=pre_break_penalty_code then
     begin if not is_char_node(cur_q)and(type(cur_q)=penalty_node) then
-      if (penalty(cur_q)>-10000)and(penalty(cur_q)<10000) then
+      begin if (penalty(cur_q)>-10000)and(penalty(cur_q)<10000) then
         if (kinsoku_penalty(kp)>=10000) then penalty(cur_q):=10000
         else if (kinsoku_penalty(kp)<=-10000) then penalty(cur_q):=-10000
         else begin penalty(cur_q):=penalty(cur_q)+kinsoku_penalty(kp);
           if (penalty(cur_q)>=10000) then penalty(cur_q):=10000
           else if (penalty(cur_q)<=-10000) then penalty(cur_q):=-10000;
           end
+      end
     else
       begin main_p:=link(cur_q); link(cur_q):=new_penalty(kinsoku_penalty(kp));
       subtype(link(cur_q)):=kinsoku_pena; link(link(cur_q)):=main_p;
@@ -6433,7 +6434,14 @@ begin kp:=get_kinsoku_pos(cur_chr,cur_pos);
 if kp<>no_entry then if kinsoku_penalty(kp)<>0 then
   begin if kinsoku_type(kp)=pre_break_penalty_code then
     if not is_char_node(tail)and(type(tail)=penalty_node) then
-      penalty(tail):=penalty(tail)+kinsoku_penalty(kp)
+      begin if (penalty(tail)>-10000)and(penalty(tail)<10000) then
+        if (kinsoku_penalty(kp)>=10000) then penalty(tail):=10000
+        else if (kinsoku_penalty(kp)<=-10000) then penalty(tail):=-10000
+        else begin penalty(tail):=penalty(tail)+kinsoku_penalty(kp);
+          if (penalty(tail)>=10000) then penalty(tail):=10000
+          else if (penalty(tail)<=-10000) then penalty(tail):=-10000;
+          end
+      end
     else
       begin tail_append(new_penalty(kinsoku_penalty(kp)));
       subtype(tail):=kinsoku_pena;


### PR DESCRIPTION
ltj-jfmglue.lua のコードを参考に（関連： #11, [luatexja#37465](https://ja.osdn.net/ticket/browse.php?group_id=5593&tid=37465)），前禁則ペナルティの合算処理の部分を「元々のペナルティが有限の場合だけ，禁則ペナルティを加味する」としてみたものです。

~~81c443d までのコードでは，[既にあがっている通り](https://github.com/texjporg/tex-jp-build/pull/26#issuecomment-329175453)，~~

~~~~ tex
\prebreakpenalty`い=-10000
\postbreakpenalty`あ=10000
あ\penalty5000 い
~~~~

~~の処理結果が LuaTeX-ja と pTeX  では異なり，どういう仕様にするかは悩んでいるところです。~~ → この例は禁則ペナルティに負の値を設定していて通常では考えづらいので，例としては取り下げます。