### PR TITLE
wovp2ovf: exit if OFMLEVEL undefined and char>0xff

### DIFF
--- a/source/texk/web2c/omegaware/ovp2ovf.ch
+++ b/source/texk/web2c/omegaware/ovp2ovf.ch
@@ -200,6 +200,12 @@ endif('notdef')
 @d out(#)==putbyte(#,tfm_file)
 @z
 
+@x [???] Eliminate nonlocal goto, uexit with a bad exit code.
+  goto final_end;
+@y
+  uexit(1);
+@z
+
 @x [165] Fix output of reals.
 @p procedure out_scaled(x:fix_word); {outputs a scaled |fix_word|}
 var @!n:byte; {the first byte after the sign}

--- a/source/texk/web2c/omegaware/ovp2ovf.web
+++ b/source/texk/web2c/omegaware/ovp2ovf.web
@@ -94,6 +94,7 @@ the |output| file, so that all such output can be easily deflected.
 @d print_ln(#)==write_ln(#)
 
 @p program OVP2OVF(@!vpl_file,@!vf_file,@!tfm_file,@!output);
+label @<Labels in the outer block@>@/
 const @<Constants in the outer block@>@/
 type @<Types in the outer block@>@/
 var @<Globals in the outer block@>@/
@@ -102,6 +103,13 @@ procedure initialize; {this procedure gets things started properly}
   begin print_ln(banner);@/
   @<Set initial values@>@/
   end;
+
+@ If the program has to stop prematurely, it goes to the
+`|final_end|' (addition in OVP2OVF).
+
+@d final_end=9999 {label for the end of it all}
+
+@<Labels...@>=final_end;
 
 @ The following parameters can be changed at compile time to extend or
 reduce \.{VPtoVF}'s capacity.
@@ -3455,14 +3463,19 @@ will be~1.
 @<Compute the subfile sizes@>=
 lh:=header_ptr div 4;@/
 not_found:=true; bc:=0;
-if (ofm_level=-1) then ec:=255 @+ else ec:=max_char;
+if (ofm_level=-1) then ec:=255 @+ else ec:=max_char; {only temporary}
 while not_found do
   if (char_wd[bc]>0)or(bc=ec) then not_found:=false
   else incr(bc);
-not_found:=true;
+not_found:=true; ec:=max_char;
 while not_found do
   if (char_wd[ec]>0)or(ec=0) then not_found:=false
   else decr(ec);
+if (ofm_level=-1)and(ec>255) then begin
+  print('Char '); print_hex(ec);
+  print_ln(' too big for TFM (max "FF); use OFM file!');
+  goto final_end;
+  end;
 if bc>ec then bc:=1;
 incr(memory[width]); incr(memory[height]); incr(memory[depth]);
 incr(memory[italic]);@/
@@ -4039,6 +4052,7 @@ read_input; print_ln('.');@/
 corr_and_check;@/
 @<Do the font metric output@>;
 vf_output;
+final_end:
 end.
 
 @ @<Global...@>=


### PR DESCRIPTION
jis.vf のような VF を松田さんの disvf.pl（[アーカイブ](https://web.archive.org/web/20090517083043/http://itohws03.ee.noda.sut.ac.jp/%7Ematsuda/ttf2pk)から取れるもの）を使用して

~~~~
$ perl disvf.pl jis.vf >jis0.ovp
~~~~

として得られる jis0.ovp を ovp2ovf C version でコンパイルすると

~~~~
$ ovp2ovf jis0.ovp
line 53042 (fatal): Char (7e7e) too big for TFM (max ff); use OFM file
~~~~

とエラーが出て，0 byte の VF が出ますが，WEB version (wovp2ovf) はエラーが出ず，不正な VF を吐いてしまいます。これを C version と互換に修正するパッチを書いてみました。

~~~~
$ wovp2ovf jis0.ovp && echo O
Char "7E7E too big for TFM (max "FF); use OFM file!
~~~~

のようにエラーを出します。問題なさそうなら TeX Live にコミット予定です。

----

以下はメモ：

- 昔の (w)ovp2ovf は無条件に「OVP に書かれている全文字コードをコンパイル」だった。
- 最近のもの (WEB version >1.12 and C version 2.1) は OVP ファイルに `(OFMLEVEL H 0)` がないと，0xff 以上の文字を受け付けない仕様になっている。
- C version は「受け付けない」旨のエラーと exit code 1 を返すが，WEB version は exit code 0 なので，不正な VF になっていることに気づかない。これを直すのがこのリクエスト。