### PR TITLE
ptex-base.ch: subtype for JFM glue in math list

### DIFF
--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -3957,7 +3957,8 @@ if (math_type(subscr(q))=empty)and(math_type(supscr(q))=empty)and@|
              add_glue_ref(gq); link(gp):=get_node(small_node_size);
              gp:=link(gp); glue_ptr(gp):=null; link(gp):=null;
              end;
-           p:=new_glue(gq); link(p):=link(q); link(q):=p; return;
+           p:=new_glue(gq); subtype(p):=jfm_skip+1;
+           link(p):=link(q); link(q):=p; return;
            end
          else begin p:=new_kern(char_kern(cur_f)(cur_i));
            link(p):=link(q); link(q):=p; return;


### PR DESCRIPTION
数式リストの \showbox 時に，JFM グルーの `\glue` の後に `(refer from jfm)` が抜けているのが気になったので，きちんと subtype を与えるようにしてみたつもりのものです。

```` tex
\tracingonline1
\showboxbreadth10000
\showboxdepth10000
\documentclass{jarticle}
\begin{document}

\setbox0=\hbox{\hbox{あA=Aあ\inhibitglue （あ）（あ）\inhibitglue （あ）}あ}
\showbox0 \box0
\setbox2=\hbox{$あA=Aあ\inhibitglue （あ）（あ）\inhibitglue （あ）$あ}
\showbox2 \box2
\setbox4=\hbox{$\hbox{あA=Aあ\inhibitglue （あ）（あ）\inhibitglue （あ）}$あ}
\showbox4 \box4

\ifmmode\typeout{あ}\else\typeout{う}\fi
$\ifmmode\typeout{あ}\else\typeout{う}\fi$
$\hbox{\ifmmode\typeout{あ}\else\typeout{う}}\fi$

\end{document}
````

この \showbox2 のときに従来は

````
.\glue 4.58203 minus 2.291
````

だったのが

````
.\glue(refer from jfm) 4.58203 minus 2.291
````

になります。（ちなみに，\inhibitglue は数式モード内では無視されるようなので，一応 ptex-manual にドキュメント化しておこうと思います）