### PR TITLE
upbibtex: fix bug and remove unused code on substring$

### DIFF
--- a/source/texk/web2c/uptexdir/upbibtex.ch
+++ b/source/texk/web2c/uptexdir/upbibtex.ch
@@ -258,35 +258,18 @@ end;
 @y
 { |2..4| bytes Kanji code break check }
 tps:=str_start[pop_lit3];
-while (tps < sp_ptr) do begin
-    tps := tps + multibytelen(str_pool[tps])
-end;
 tpe:=tps;
-while (tpe < sp_end) do begin
-    tpe := tpe + multibytelen(str_pool[tpe])
+while tpe < str_start[pop_lit3+1] do begin
+    if multibytelen(str_pool[tpe])<0
+        or (str_start[pop_lit3+1] < tpe+multibytelen(str_pool[tpe])) then
+        break;
+    tpe := tpe + multibytelen(str_pool[tpe]);
+    if sp_end<=tpe then break;
+    if tpe<=sp_ptr then
+        tps := tpe;
 end;
-if tps<>sp_ptr then begin
-    if (is_internalUPTEX) then begin
-        if tps>str_start[pop_lit3]
-        then while (multibytelen(str_pool[sp_ptr])<0) do decr(sp_ptr)
-        else while (multibytelen(str_pool[sp_ptr])<0) do incr(sp_ptr)
-    end else begin
-        if tps>str_start[pop_lit3]
-        then decr(sp_ptr)
-        else incr(sp_ptr)
-    end;
-end;
-if tpe<>sp_end then begin
-    if (is_internalUPTEX) then begin
-        if tpe<str_start[pop_lit3+1]
-        then while (multibytelen(str_pool[sp_end])<0) do incr(sp_end)
-        else while (multibytelen(str_pool[sp_end])<0) do decr(sp_end)
-    end else begin
-        if tpe<str_start[pop_lit3+1]
-        then incr(sp_end)
-        else decr(sp_end)
-    end;
-end;
+sp_ptr := tps;
+sp_end := tpe;
 @z
 
 @x
@@ -299,16 +282,7 @@ end;
          end;
 @y
     append_char (str_pool[sp_ptr]);
-    if multibytelen(str_pool[sp_ptr]) > 1 then
-        append_char (str_pool[sp_ptr+1]);
-    if multibytelen(str_pool[sp_ptr]) > 2 then
-        append_char (str_pool[sp_ptr+2]);
-    if multibytelen(str_pool[sp_ptr]) > 3 then
-        append_char (str_pool[sp_ptr+3]);
-    if multibytelen(str_pool[sp_ptr]) > 0 then
-        sp_ptr := sp_ptr + multibytelen(str_pool[sp_ptr])
-    else
-        incr(sp_ptr);
+    incr(sp_ptr);
 @z
 
 @x


### PR DESCRIPTION
* ```tips<str_start[pop_lit3]```となるケース（[272行](https://github.com/texjporg/tex-jp-build/commit/31797a34ebfff54d7322a4054b29ba11f7b0ba78#diff-84150b8b969bf4c04c244f71f3d77061L272)ほか）は必要なさそうだったので削除
* 内部文字コードがupTeXのときだけアルゴリズムを分けること（[269行](https://github.com/texjporg/tex-jp-build/commit/31797a34ebfff54d7322a4054b29ba11f7b0ba78#diff-84150b8b969bf4c04c244f71f3d77061L269)）をしないで済むようアルゴリズムを変更
* 不正文字のチェックを追加（[新263行](https://github.com/texjporg/tex-jp-build/commit/31797a34ebfff54d7322a4054b29ba11f7b0ba78#diff-84150b8b969bf4c04c244f71f3d77061R263)）
* 問題の原因だったコピー時のマルチコード文字列チェック（[302行](https://github.com/texjporg/tex-jp-build/commit/31797a34ebfff54d7322a4054b29ba11f7b0ba78#diff-84150b8b969bf4c04c244f71f3d77061L302)〜）を削除

動作に目立った変化があれば分かるように次のようなテストファイルの出力を比較したが、差はありませんでした。
[test_upbibtex.zip](https://github.com/texjporg/tex-jp-build/files/2364119)