### PR TITLE
\iffontchar, \fontcharwd など

### DIFF
--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -528,7 +528,7 @@ read_papersize_special_code:print_esc("readpapersizespecial");
   end;
 @y
   if font_dir[q]<>dir_default then {Japanese font}
-    begin if cur_val>=256 then {Japanese Character}
+    begin if is_char_kanji(cur_val) then {Japanese Character}
       begin cur_val:=get_jfm_pos(KANJI(cur_val),q);
       i:=orig_char_info(q)(qi(cur_val));
       case m of

--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -244,6 +244,21 @@ end
     last_node_subtype_code: cur_val:=last_node_subtype;
 @z
 
+@x
+procedure scan_ascii_num;
+@y
+procedure scan_char_type;
+begin scan_int;
+if (cur_val<0)or(cur_val>255) then
+  begin print_err("Bad character type");
+@.Bad character type@>
+  help2("A character type must be between 0 and 255.")@/
+    ("I changed this one to zero."); int_error(cur_val); cur_val:=0;
+  end;
+end;
+procedure scan_ascii_num;
+@z
+
 @x e-pTeX: if primitives - leave room for three e-TeX codes
 @d if_tdir_code=if_case_code+1 { `\.{\\iftdir}' }
 @y
@@ -624,8 +639,16 @@ othercases goto next_p
 @z
 
 @x e-pTeX: if_font_char_code l.28633
+if_font_char_code:begin scan_font_ident; n:=cur_val; scan_char_num;
+  if (font_bc[n]<=cur_val)and(font_ec[n]>=cur_val) then
     b:=char_exists(char_info(n)(qi(cur_val)))
 @y
+if_font_char_code:begin scan_font_ident; n:=cur_val;
+  if font_dir[n]<>dir_default then {Japanese font}
+    scan_char_type
+  else
+    scan_char_num;
+  if (font_bc[n]<=cur_val)and(font_ec[n]>=cur_val) then
     b:=char_exists(orig_char_info(n)(qi(cur_val)))
 @z
 


### PR DESCRIPTION
texjporg/ptex-manual#3 の (★1) (★2) に対する修正です。

1efab15 が (★1) に関する

> 和文フォントの場合： 与えられた ⟨character code⟩ を文字タイプとみなし，JFM に文字タイプが存在すれば真，しなければ偽を返す。

を仕様とみなし，

> 数値としては ⟨character code⟩ を受け入れるが，実際は文字タイプとして扱われる

の数値のチェックで厳密に 0--255 しか受け付けないようにするものです。

ac9f777 が (★2) に関して

> 与えられた ⟨character code⟩ が 256 以上であれば寸法を返し，256 未満であれば 0pt を返す

を「256」ではなく「和文文字コードとして有効かどうか」に変えるものです。