### PR TITLE
upTeX 1.24 での全角英数・半角カナの \kcatcode のデフォルト値

### DIFF
--- a/source/texk/web2c/uptexdir/kanji.c
+++ b/source/texk/web2c/uptexdir/kanji.c
@@ -444,7 +444,7 @@ integer kcatcodekey(integer c)
                || (LATIN_SMALL_LETTER_O_WITH_STROKE  <=c && c<=LATIN_SMALL_LETTER_Y_WITH_DIAERESIS  ) )
             return 0x1FD;
         }
-        if (block==0xa0) {
+        if (block==0xa1) {
             /* Fullwidth ASCII variants  except for U+FF01..FF0F, U+FF1A..FF20, U+FF3B..FF40, U+FF5B..FF5E */
             if (  (FULLWIDTH_DIGIT_0  <=c && c<=FULLWIDTH_DIGIT_9  )
                || (FULLWIDTH_CAPITAL_A<=c && c<=FULLWIDTH_CAPITAL_Z)


### PR DESCRIPTION
upTeX 1.24 での全角英数・半角カナの `\kcatcode` のデフォルト値が 17 ではなく 18 なってしまっています。
[`kanji.c`](https://github.com/texjporg/tex-jp-build/blob/master/source/texk/web2c/uptexdir/kanji.c) および [`uptex-m.ch`](https://github.com/texjporg/tex-jp-build/blob/master/source/texk/web2c/uptexdir/uptex-m.ch) を見ると，これは意図通りではないと思われます。

```c
        if (block==0xa0) {
            /* Fullwidth ASCII variants  except for U+FF01..FF0F, U+FF1A..FF20, U+FF3B..FF40, U+FF5B..FF5E */
            if (  (FULLWIDTH_DIGIT_0  <=c && c<=FULLWIDTH_DIGIT_9  )
               || (FULLWIDTH_CAPITAL_A<=c && c<=FULLWIDTH_CAPITAL_Z)
               || (FULLWIDTH_SMALL_A  <=c && c<=FULLWIDTH_SMALL_Z  ) )
            return 0x1FE;
        /* Halfwidth Katakana variants  except for U+FF65, U+FF70, U+FF9E..FF9F */
            if (  (HALFWIDTH_KATAKANA_WO <=c && c<=HALFWIDTH_KATAKANA_SMALL_TSU )
               || (HALFWIDTH_KATAKANA_A  <=c && c<=HALFWIDTH_KATAKANA_N  ) )
            return 0x1FF;
        }
```

```
  @t\hskip10pt@>kcat_code(@"1FE):=kana; { Fullwidth digit and latin alphabet }
  @t\hskip10pt@>kcat_code(@"1FF):=kana; { Halfwidth katakana }
```

おそらく，[c3e79f1155fc99fc9f1dc3e184735489944244f2](https://github.com/texjporg/tex-jp-build/commit/c3e79f1155fc99fc9f1dc3e184735489944244f2#diff-96f5b9df3f02b4e1b1737b6df3472fc5) において `ucs_range` に

```c
0x1C90, /* Georgian Extended				     */
```

のブロックが増えたときにインデックスがずれたのが

```c
 if (block==0xa0) {
```

に反映されていないためではないかと思われます。ここを

```c
 if (block==0xa1) {
```

に修正してビルドしたところ，全角英数・半角カナの `\kcatcode` のデフォルト値が 17 に戻りました。