### PR TITLE
eptex.ech: more compatible with original e-TeX

### DIFF
--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -553,7 +553,7 @@ font_char_ic_code: begin scan_font_ident; q:=cur_val;
       end
     else cur_val:=0;
     end
-  else begin scan_char_num;
+  else begin scan_ascii_num;
     if (font_bc[q]<=cur_val)and(font_ec[q]>=cur_val) then
       begin i:=orig_char_info(q)(qi(cur_val));
       case m of
@@ -646,7 +646,7 @@ if_font_char_code:begin scan_font_ident; n:=cur_val; scan_char_num;
   end;
 @y
 if_font_char_code:begin scan_font_ident; n:=cur_val;
-  if font_dir[n]<>dir_default then
+  if font_dir[n]<>dir_default then {Japanese font}
     begin scan_int;
     if cur_val>=0 then b:=is_char_kanji(cur_val)
     { In u\pTeX, $\hbox{|is_char_kanji|} = \lambda x\mathpunct{.} x\ge 0$ }
@@ -655,7 +655,7 @@ if_font_char_code:begin scan_font_ident; n:=cur_val;
       b:=(font_bc[n]<=cur_val)and(font_ec[n]>=cur_val)
       end
     end
-  else begin scan_char_num;
+  else begin scan_ascii_num;
     if (font_bc[n]<=cur_val)and(font_ec[n]>=cur_val) then @/
       b:=char_exists(orig_char_info(n)(qi(cur_val)))
     else b:=false;


### PR DESCRIPTION
e-pTeX 190709 の `\iffontchar` と `\fontchar??` の欧文フォントでの挙動について：

和文フォントに対しては，引数が何であれエラーは出ないようになっています。

* `\iffontchar`: 引数が非負のときは is_char_kanji．負数 c のときは文字タイプ -(c + 1) の存在判定
* `\fontchar??`: 引数が非負のときは「is_char_kanji なら寸法値，そうでなければ 0」，引数が負数 c のときは文字タイプ -(c + 1) の存在判定

一方，欧文フォントに対しては，現状では「引数が有効な文字コードでない場合」すなわち「0--255 からも**漢字コードからも**外れた場合」に "! Bad character code." エラーが出ます。

エラーが出ること自体は元の e-TeX 由来なので維持するとして，エラーを出す条件を「0--255 から外れた場合」に厳しくすれば元の e-TeX と同じに出来るので，そうしてみました。