### PR TITLE
e(u)ptex: add \current(x)spacingmode, \currentcjktoken

### DIFF
--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -727,12 +727,8 @@ current_spacing_mode_code: print_esc("currentspacingmode");
 current_xspacing_mode_code: print_esc("currentxspacingmode");
 
 @ @<Cases for fetching an integer value@>=
-current_spacing_mode_code: begin
-  if auto_spacing>0 then cur_val:=1 else cur_val:=0;
-  end;
-current_xspacing_mode_code: begin
-  if auto_xspacing>0 then cur_val:=1 else cur_val:=0;
-  end;
+current_spacing_mode_code: cur_val:=auto_spacing;
+current_xspacing_mode_code: cur_val:=auto_xspacing;
 
 @* \[56] System-dependent changes.
 @z

--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -110,6 +110,12 @@ var m:halfword; {|chr_code| part of the operand token}
 @d eptex_version_code=ptex_minor_version_code+1 {code for \.{\\epTeXversion}}
 @z
 
+@x e-pTeX: \current(x)spacingmode
+@d eTeX_dim=eTeX_int+8 {first of \eTeX\ codes for dimensions}
+@y
+@d eTeX_dim=eTeX_int+10 {first of \eTeX\ codes for dimensions}
+@z
+
 @x
 primitive("ptexversion",last_item,ptex_version_code);
 @!@:ptexversion_}{\.{\\ptexversion} primitive@>
@@ -698,4 +704,35 @@ print(" direction"); end;
 end;
 @#
 procedure print_direction(@!d:integer); {print the direction represented by d}
+@z
+
+@x e-pTeX: fetch \(no)auto(x)spacing status
+@* \[56] System-dependent changes.
+@y
+@ The \.{\\currentspacingmode} and \.{\\currentxspacingmode} commands
+return the current \pTeX's status of \.{\\(no)autospacing} and
+\.{\\(no)autoxspacing} respectively.
+
+@d current_spacing_mode_code=eTeX_int+8 {code for \.{\\currentspacingmode}}
+@d current_xspacing_mode_code=eTeX_int+9 {code for \.{\\currentxspacingmode}}
+
+@<Generate all \eTeX...@>=
+primitive("currentspacingmode",last_item,current_spacing_mode_code);
+@!@:current_spacing_mode_}{\.{\\currentspacingmode} primitive@>
+primitive("currentxspacingmode",last_item,current_xspacing_mode_code);
+@!@:current_xspacing_mode_}{\.{\\currentxspacingmode} primitive@>
+
+@ @<Cases of |last_item| for |print_cmd_chr|@>=
+current_spacing_mode_code: print_esc("currentspacingmode");
+current_xspacing_mode_code: print_esc("currentxspacingmode");
+
+@ @<Cases for fetching an integer value@>=
+current_spacing_mode_code: begin
+  if auto_spacing>0 then cur_val:=1 else cur_val:=0;
+  end;
+current_xspacing_mode_code: begin
+  if auto_xspacing>0 then cur_val:=1 else cur_val:=0;
+  end;
+
+@* \[56] System-dependent changes.
 @z

--- a/source/texk/web2c/euptexdir/euptex.ch1
+++ b/source/texk/web2c/euptexdir/euptex.ch1
@@ -12,6 +12,12 @@
 @d uptex_version_code=ptex_minor_version_code+2 {code for \.{\\uptexversion}}
 @z
 
+@x e-upTeX: \currentcjktoken
+@d eTeX_dim=eTeX_int+10 {first of \eTeX\ codes for dimensions}
+@y
+@d eTeX_dim=eTeX_int+11 {first of \eTeX\ codes for dimensions}
+@z
+
 @x
   eptex_version_code: print_esc("epTeXversion");
 @y
@@ -75,4 +81,25 @@ if j=1 then
   else
     begin buffer[m]:=info(p) mod max_char_val; incr(m); p:=link(p);
     end;
+@z
+
+@x e-upTeX: fetch \(disable|enable|force)cjktoken status
+@* \[54] System-dependent changes.
+@y
+@ The \.{\\currentcjktoken} command returns the current \upTeX's
+status of \.{\\(disable|enable|force)cjktoken}.
+
+@d current_cjk_token_code=eTeX_int+10 {code for \.{\\currentcjktoken}}
+
+@<Generate all \eTeX...@>=
+primitive("currentcjktoken",last_item,current_cjk_token_code);
+@!@:current_cjk_token_}{\.{\\currentcjktoken} primitive@>
+
+@ @<Cases of |last_item| for |print_cmd_chr|@>=
+current_cjk_token_code: print_esc("currentcjktoken");
+
+@ @<Cases for fetching an integer value@>=
+current_cjk_token_code: cur_val:=enable_cjk_token;
+
+@* \[54] System-dependent changes.
 @z

--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -994,7 +994,7 @@ kern_node,math_node,penalty_node: begin r:=get_node(small_node_size);
 @d hyph_data=set_box+1 {hyphenation data ( \.{\\hyphenation}, \.{\\patterns} )}
 @d set_interaction=hyph_data+1 {define level of interaction ( \.{\\batchmode}, etc.~)}
 @d set_auto_spacing=set_interaction+1 {set auto spacing mode
-  ( \.{\\autospacing}, \.{\\noautospacing}, ( \.{\\autoxspacing}, \.{\\noautoxspacing} )}
+  ( \.{\\autospacing}, \.{\\noautospacing}, \.{\\autoxspacing}, \.{\\noautoxspacing} )}
 @d max_command=set_auto_spacing {the largest command code seen at |big_switch|}
 @z
 


### PR DESCRIPTION
何か作りたくなったので

* e-pTeX: `\currentspacingmode`, `\currentxspacingmode` … `\(|no)autospacing`, `\(|no)autoxspacing` の状態を取得
* e-upTeX: `\currentcjktoken` ... `\(enable|disable|force)cjktoken` の状態を取得

というプリミティブを実装してみました。e-TeX の `\current...` 系命令の流儀で実装しているので extended mode でないと使えません。マクロでやろうとすると結構面倒なので（前者は `\showmode` がありますが止まってしまうし），何かに使えるかと。

``` tex
%#!euptex (or eptex)
\show\currentspacingmode
\show\currentxspacingmode

\def\SHOWSPACING{\showthe\currentspacingmode\showthe\currentxspacingmode}

\SHOWSPACING                 % => default: 1,1 (auto,autox)
\noautospacing \SHOWSPACING  % => 0,1 (noauto,autox)
\noautoxspacing \SHOWSPACING % => 0,0 (noauto,noautox)
\autospacing \SHOWSPACING    % => 1,0 (auto,noautox)
\autoxspacing \SHOWSPACING   % => 1,1 (auto,autox)

\ifx\enablecjktoken\undefined\expandafter\end\fi

\show\currentcjktoken

\def\SHOWCJK{\showthe\currentcjktoken}

\SHOWCJK                  % => default: 0 (\enablecjktoken)
\disablecjktoken \SHOWCJK % => 1 (\disablecjktoken)
\enablecjktoken \SHOWCJK  % => 0 (\enablecjktoken)
\forcecjktoken \SHOWCJK   % => 2 (\forcecjktoken)

\end
```

一応，マクロで状態を知ることは出来なくはない：[showmode.tex](https://gist.github.com/aminophen/349047741ea01b8af3cfdca3613fe90a), [showcjk.tex](https://gist.github.com/aminophen/1f33a84e2d1dbaaa46465abaada0c619)