### PR TITLE
Fix for texjporg/tex-jp-build#113 and texjporg/ptex-manual#4

### DIFF
--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -2562,7 +2562,7 @@ else begin
   end
 @z
 
-@x [28.502] l.10138 - pTeX: ifx : Test character : KANJI character
+@x [28.502] l.10138 - pTeX: if[cat] : Test character : KANJI character
 if (cur_cmd>active_char)or(cur_chr>255) then {not a character}
   begin m:=relax; n:=256;
   end
@@ -2574,7 +2574,7 @@ if (cur_cmd>active_char)or(cur_chr>255) then
   end;
 @y
 if (cur_cmd=kanji)or(cur_cmd=kana)or(cur_cmd=other_kchar) then
-  begin n:=cur_chr; m:=kcat_code(kcatcodekey(n));
+  begin m:=cur_cmd; n:=cur_chr;
   end
 else if (cur_cmd>active_char)or(cur_chr>255) then
   begin m:=relax; n:=max_cjk_val;
@@ -2583,8 +2583,8 @@ else  begin m:=cur_cmd; n:=cur_chr;
   end;
 get_x_token_or_active_char;
 if (cur_cmd=kanji)or(cur_cmd=kana)or(cur_cmd=other_kchar) then
-  begin cur_cmd:=kcat_code(kcatcodekey(cur_chr));
-  end
+  begin cur_cmd:=cur_cmd;
+  end {dummy}
 else if (cur_cmd>active_char)or(cur_chr>255) then
   begin cur_cmd:=relax; cur_chr:=max_cjk_val;
   end;

--- a/source/texk/web2c/ptexdir/ptex-base.ch
+++ b/source/texk/web2c/ptexdir/ptex-base.ch
@@ -1249,10 +1249,27 @@ if n<math_code_base then
     begin print_esc("xspcode"); print_int(n-auto_xsp_code_base);
     end
   else if n<kinsoku_base then
-    begin print("(inhibitxspcode table) "); print_int(n-inhibit_xsp_code_base);
+    begin print("inhibitxspcode table "); print_int(n-inhibit_xsp_code_base);
+      print(", type=");
+      case eq_type(n) of
+        0: print("both");   { |inhibit_both| }
+        1: print("before"); { |inhibit_previous| }
+        2: print("after");  { |inhibit_after| }
+        3: print("none");   { |inhibit_none| }
+        4: print("unused"); { |inhibit_unused| }
+      end; {there are no other cases}
+      print(", code");
     end
   else if n<kansuji_base then
-    begin print("(kinsoku table) "); print_int(n-kinsoku_base);
+    begin print("kinsoku table "); print_int(n-kinsoku_base);
+      print(", type=");
+      case eq_type(n) of
+        0: print("no");
+        1: print("pre");    { |pre_break_penalty_code| }
+        2: print("post");   { |post_break_penalty_code| }
+        3: print("unused"); { |kinsoku_unused_code| }
+      end; {there are no other cases}
+      print(", code");
     end
   else if n<lc_code_base then
     begin print_esc("kansujichar"); print_int(n-kansuji_base);
@@ -1412,7 +1429,10 @@ end;
 tats
 @y
 else if n<kinsoku_penalty_base then @<Show equivalent |n|, in region 6@>
-else if n<=eqtb_size then print("kinsoku")
+else if n<=eqtb_size then begin
+  print("kinsoku table "); print_int(n-kinsoku_penalty_base);
+  print(", penalty="); print_int(eqtb[n].int);
+  end
 else print_char("?"); {this can't happen either}
 end;
 tats
@@ -6574,19 +6594,23 @@ assign_inhibit_xsp_code: print_esc("inhibitxspcode");
 @ @<Declare procedures needed in |scan_something_internal|@>=
 function get_inhibit_pos(c:KANJI_code; n:small_number):pointer;
 label done, done1;
-var p,s:pointer;
-begin s:=calc_pos(c); p:=s;
+var p,pp,s:pointer;
+begin s:=calc_pos(c); p:=s; pp:=no_entry;
 if n=new_pos then
   begin repeat
-  if (inhibit_xsp_type(p)=inhibit_unused)or(inhibit_xsp_code(p)=0)
-    or(inhibit_xsp_code(p)=c) then goto done;
+  if inhibit_xsp_code(p)=c then goto done;  { found, update there }
+  if inhibit_xsp_code(p)=0 then             { no further scan needed }
+    begin if pp<>no_entry then p:=pp; goto done; end;
+  if inhibit_xsp_type(p)=inhibit_unused then
+    if pp=no_entry then pp:=p; { save the nearest unused hash }
   incr(p); if p>255 then p:=0;
-  until s=p; p:=no_entry;
+  until s=p;
+  p:=pp;
   end
 else
   begin repeat
-  if inhibit_xsp_code(p)=0 then goto done1
-  else if (inhibit_xsp_type(p)<>inhibit_unused)and(inhibit_xsp_code(p)=c) then goto done;
+  if inhibit_xsp_code(p)=0 then goto done1;
+  if inhibit_xsp_code(p)=c then goto done;
   incr(p); if p>255 then p:=0;
   until s=p;
 done1: p:=no_entry;
@@ -6621,6 +6645,7 @@ end;
 begin scan_int; q:=get_inhibit_pos(tokanji(cur_val),cur_pos);
 cur_val_level:=int_val; cur_val:=inhibit_none;
 if q<>no_entry then cur_val:=inhibit_xsp_type(q);
+if cur_val>inhibit_none then cur_val:=inhibit_none;
 end
 
 @ The \.{\\prebreakpenalty} is used to specified amount of penalties inserted
@@ -6646,8 +6671,8 @@ assign_kinsoku: case chr_code of
 @ @<Declare procedures needed in |scan_something_internal|@>=
 function get_kinsoku_pos(c:KANJI_code; n:small_number):pointer;
 label done, done1;
-var p,s:pointer;
-begin s:=calc_pos(c); p:=s;
+var p,pp,s:pointer;
+begin s:=calc_pos(c); p:=s; pp:=no_entry;
 @!debug
 print_ln; print("c:="); print_int(c); print(", p:="); print_int(s);
 if p+kinsoku_base<0 then
@@ -6656,16 +6681,19 @@ if p+kinsoku_base<0 then
 gubed
 if n=new_pos then
   begin repeat
-  if (kinsoku_type(p)=0)or(kinsoku_type(p)=kinsoku_unused_code)
-    or(kinsoku_code(p)=c) then goto done;
+  if kinsoku_code(p)=c then goto done;  { found, update there }
+  if kinsoku_type(p)=0 then             { no further scan needed }
+    begin if pp<>no_entry then p:=pp; goto done; end;
+  if kinsoku_type(p)=kinsoku_unused_code then
+    if pp=no_entry then pp:=p; { save the nearest unused hash }
   incr(p); if p>255 then p:=0;
   until s=p;
-  p:=no_entry;
+  p:=pp;
   end
 else
   begin repeat
-  if kinsoku_type(p)=0 then goto done1
-  else if (kinsoku_type(p)<>kinsoku_unused_code)and(kinsoku_code(p)=c) then goto done;
+  if kinsoku_type(p)=0 then goto done1;
+  if kinsoku_code(p)=c then goto done;
   incr(p); if p>255 then p:=0;
   until s=p;
 done1: p:=no_entry;

--- a/source/texk/web2c/ptexdir/tests/kinsoku_search.tex
+++ b/source/texk/web2c/ptexdir/tests/kinsoku_search.tex
@@ -1,0 +1,43 @@
+%#!euptex -ini -etex
+\tracingonline1
+\tracingassigns1
+
+% 最優先hashはコードポイントから一意に決まる値（jtex.pdfも参照）
+\prebreakpenalty`、=10000 % code=12289, 最優先hash=1
+\prebreakpenalty`。=10000 % code=12290, 最優先hash=2
+\prebreakpenalty`ぁ=150 % code=12353, 最優先hash=1だが埋まってしまったので3に分配
+\prebreakpenalty`ぃ=150 % code=12355, 最優先hash=3だが埋まってしまったので4に分配
+
+\showthe\currentgrouplevel % > 0.
+\showthe\prebreakpenalty`ぃ % > 150.
+
+\prebreakpenalty`ぃ=0 % changing hash=4
+\showthe\prebreakpenalty`ぃ % > 0. ← OK（hash=4読出）
+
+\prebreakpenalty`ぃ=123 % changing hash=4
+\showthe\prebreakpenalty`ぃ % > 123. ← OK（hash=4読出）
+
+\prebreakpenalty`ぁ=0 % changing hash=3
+\showthe\prebreakpenalty`ぃ % > 123. ← OK（hash=4読出）
+
+% この時点で "ぁ" が消えてhash=3が空いている。
+% 一方，"ぃ"はフォールバックしたhash=4に格納されている。
+
+\prebreakpenalty`ぃ=0 % changing hash=4
+\showthe\prebreakpenalty`ぃ % > 0. ← 修正（削除済み）
+
+\prebreakpenalty`ぃ=234 % changing hash=3
+\showthe\prebreakpenalty`ぃ % > 234. ← OK（hash=3読出）
+
+\prebreakpenalty`ぃ=0 % changing hash=3
+\showthe\prebreakpenalty`ぃ % > 0. ← 修正（削除済み）
+
+\prebreakpenalty`ぁ=345 % changing hash=3
+\showthe\prebreakpenalty`ぃ % > 0. ← 修正（削除済み）
+
+% この時点で "ぁ" が再びhash=3を埋めている。
+
+\prebreakpenalty`ぃ=0 % reassigning hash=4
+\showthe\prebreakpenalty`ぃ % > 0. ← OK（削除済み）
+
+\end

--- a/source/texk/web2c/ptexdir/tests/kinsoku_table.tex
+++ b/source/texk/web2c/ptexdir/tests/kinsoku_table.tex
@@ -1,44 +1,47 @@
-%#!uptex
+%#!uptex -ini
+\let\dump\relax
+\input plain
 \newcount\fuga\newcount\dflt
+\fuga="3300
 \iffalse
   \global\let\prebreakpenalty=\inhibitxspcode
-  \fuga="30D3 \dflt=3
+  \dflt=3
 \else
-  \fuga="3090 \dflt=0
+  \dflt=0
 \fi
 
 \scrollmode
 \newcount\hoge\hoge="3000
 \loop\ifnum\hoge<\fuga
   \message{\the\hoge}\prebreakpenalty\hoge=2
-  \advance\hoge 1\relax \repeat
+  \advance\hoge 3\relax \repeat
 
-\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% 2, D
+\message{<\the\prebreakpenalty"3003, \the\prebreakpenalty"4000>}% 2, D
 {
-  \prebreakpenalty"3001=\dflt\relax
+  \prebreakpenalty"3003=\dflt\relax
   \global\prebreakpenalty"4000=1\relax% error
-\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% D, D
+\message{<\the\prebreakpenalty"3003, \the\prebreakpenalty"4000>}% D, D
 }
 
-\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% 2, D
+\message{<\the\prebreakpenalty"3003, \the\prebreakpenalty"4000>}% 2, D
 
 {
-  \global\prebreakpenalty"3001=\dflt\relax
+  \global\prebreakpenalty"3003=\dflt\relax
   \prebreakpenalty"4000=1\relax% no error
-\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% D, 1
+\message{<\the\prebreakpenalty"3003, \the\prebreakpenalty"4000>}% D, 1
 }
-\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000>}% D, D
+\message{<\the\prebreakpenalty"3003, \the\prebreakpenalty"4000>}% D, D
 
 \prebreakpenalty"4000=1\relax% no error
 
-\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000,
+\message{<\the\prebreakpenalty"3003, \the\prebreakpenalty"4000,
   \the\prebreakpenalty"3549>}% D, 1, D
 
 \prebreakpenalty"4000=\dflt\relax
 
 \prebreakpenalty"3549=1\relax% no error
 
-\message{<\the\prebreakpenalty"3001, \the\prebreakpenalty"4000,
+\message{<\the\prebreakpenalty"3003, \the\prebreakpenalty"4000,
   \the\prebreakpenalty"3549>}% D, D, 1
 
 

--- a/source/texk/web2c/uptexdir/ChangeLog
+++ b/source/texk/web2c/uptexdir/ChangeLog
@@ -66,7 +66,7 @@
 2019-05-06  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
 
 	* uptex-m.ch:
-	Make appropreate comparison of U+0100 by \if.
+	Make appropriate comparison of U+0100 by \if.
 	https://github.com/texjporg/tex-jp-build/issues/68
 	* tests/test_if.tex: Test case.
 

--- a/source/texk/web2c/uptexdir/tests/test_if.tex
+++ b/source/texk/web2c/uptexdir/tests/test_if.tex
@@ -1,29 +1,56 @@
+%#!ptex
 \kcatcode`あ=18
 \def\xA{あ}\let\yA=あ
 \kcatcode`あ=17
 \def\xB{あ}\let\yB=あ
 \kcatcode`あ=16
+\def\xC{あ}\let\yC=あ
 
-\message{\ifcat あ\xA Y\else N\fi}
-\message{\ifcat あ\yA Y\else N\fi}
-\message{\ifcat あ\xB Y\else N\fi}
-\message{\ifcat あ\yB Y\else N\fi}
+%% for pTeX
+%  * x: macro -> re-eval kcatcode
+%  * y: let   -> copy kcatcode
+%% for upTeX
+%  * x: macro -> reserved kcatcode
+%  * y: let   -> copy kcatcode
 
-\message{\if    あ\xA Y\else N\fi}
-\message{\if    あ\yA Y\else N\fi}
-\message{\if    い\xA Y\else N\fi}
-\message{\if    い\yA Y\else N\fi}
+\message{ifcat}
+\message{\ifcat あ\xA Y\else N\fi}% pY, uN
+\message{\ifcat あ\yA Y\else N\fi}% pN, uN
+\message{\ifcat あ\xB Y\else N\fi}% pY, uN
+\message{\ifcat あ\yB Y\else N\fi}% pN, uN
+\message{\ifcat あ\xC Y\else N\fi}% pY, uY
+\message{\ifcat あ\yC Y\else N\fi}% pY, uY
+
+\message{if}
+\message{\if    あ\xA Y\else N\fi}% pY, uY
+\message{\if    あ\yA Y\else N\fi}% pY, uY
+\message{\if    あ\xB Y\else N\fi}% pY, uY
+\message{\if    あ\yB Y\else N\fi}% pY, uY
+\message{\if    あ\xC Y\else N\fi}% pY, uY
+\message{\if    あ\yC Y\else N\fi}% pY, uY
+\message{\if    い\xA Y\else N\fi}% pN, uN
+\message{\if    い\yA Y\else N\fi}% pN, uN
+
+\message{ifx}
+\message{\ifx   あ\xA Y\else N\fi}% pN, uN
+\message{\ifx   あ\yA Y\else N\fi}% pN, uN
+\message{\ifx   あ\xB Y\else N\fi}% pN, uN
+\message{\ifx   あ\yB Y\else N\fi}% pN, uN
+\message{\ifx   あ\xC Y\else N\fi}% pN, uN
+\message{\ifx   あ\yC Y\else N\fi}% pY, uY
+\message{\ifx  \xA\xB Y\else N\fi}% pY, uN
+\message{\ifx  \xA\xC Y\else N\fi}% pY, uN
+\message{\ifx  \yA\yB Y\else N\fi}% pN, uN
+\message{\ifx  \yA\yC Y\else N\fi}% pN, uN
 
 \ifx\ucs\undefined\else
   \kcatcode"100=16
   \message{upTeX}
   \def\xA{Ā}% U+0100
   \def\xB{ā}% U+0101
-  \message{\if   \xA\relax Y\else N\fi}
-  \message{\if   \xB\relax Y\else N\fi}
-  \message{\ifcat\xA\relax Y\else N\fi}
-  \message{\ifcat\xB\relax Y\else N\fi}
+  \message{\if   \xA\relax Y\else N\fi}% uN
+  \message{\if   \xB\relax Y\else N\fi}% uN
+  \message{\ifcat\xA\relax Y\else N\fi}% uN
+  \message{\ifcat\xB\relax Y\else N\fi}% uN
 \fi
 \end
-
-

--- a/source/texk/web2c/uptexdir/uptex-m.ch
+++ b/source/texk/web2c/uptexdir/uptex-m.ch
@@ -704,24 +704,16 @@ uptex_revision_code: print(upTeX_revision);
 
 @x
 if (cur_cmd=kanji)or(cur_cmd=kana)or(cur_cmd=other_kchar) then
-  begin n:=cur_chr; m:=kcat_code(kcatcodekey(n));
-  end
 @y
 if (cur_cmd>=kanji)and(cur_cmd<=hangul) then
-  begin m:=cur_cmd; n:=cur_chr;
-  end
 @z
 
 @x
 get_x_token_or_active_char;
 if (cur_cmd=kanji)or(cur_cmd=kana)or(cur_cmd=other_kchar) then
-  begin cur_cmd:=kcat_code(kcatcodekey(cur_chr));
-  end
 @y
 get_x_token_or_active_char;
 if (cur_cmd>=kanji)and(cur_cmd<=hangul) then
-  begin cur_cmd:=cur_cmd;
-  end {dummy}
 @z
 
 @x


### PR DESCRIPTION
pTeX の挙動について

* [(u)pTeX] 禁則テーブルのハッシュ検索バグ (texjporg/tex-jp-build#113)
* pTeX の和文文字トークンのカテゴリーコード (texjporg/ptex-manual#4)

に対する修正案を TeX Live svn に入れたいと思います。

----

## 前者（ハッシュ検索バグ）

#26, #57 で導入されたロジックに穴があることが露呈したものです。[forum での元の報告者](https://oku.edu.mie-u.ac.jp/tex/mod/forum/discuss.php?d=3113 )に「開発版 win32 バイナリ」を渡し，正常に動くことを確認していただいています。

## 後者（和文文字トークンの kcatcode）

2019-05-06 付けの「pTeX (非upTeX) では和文文字トークンが kcatcode を持たないので，制御綴に \let されたものを再計算する」を意図したコードを revert するものです。意図は，この再計算が \ifcat には効いているものの \ifx には効いておらず，結果的に不整合を起こしていたため，元の挙動に戻したいということです。

「和文文字トークンは kcatcode を持たない」という仕様／挙動の一貫性については，\let された制御綴からは再計算しない（見た目も「和文文字トークン」に見えないし…）としても大して損なわれないと考え直しました。むしろ \let で kcatcode が保持される方が使い勝手は良い気がしますし，upTeX とのコード差分も減らす方向です。