### PR TITLE
eptex.ech: \showmode follows \showstream

### DIFF
--- a/source/texk/web2c/eptexdir/eptex.ech
+++ b/source/texk/web2c/eptexdir/eptex.ech
@@ -708,6 +708,16 @@ if_font_char_code:begin scan_font_ident; n:=cur_val;
   end;
 @z
 
+@x e-pTeX: pTeX has \showmode, follow showstream.ch r61589
+@<Show the current japanese processing mode@>=
+begin print_nl("> ");
+@y
+@<Show the current japanese processing mode@>=
+begin
+  @<Adjust |selector| based on |show_stream|@>
+  print_nl("> ");
+@z
+
 @x
 procedure print_direction(@!d:integer); {print the direction represented by d}
 @y


### PR DESCRIPTION
TL2022 で追加見込みの \showstream プリミティブ（eptexdoc には記載済）について，pTeX には「\show 系プリミティブ」として \showmode があるので，出力ストリームに追随するようにしてみました。

``` tex
%#!eptex
\newwrite\myoutstream
\immediate\openout\myoutstream="infofile"
\showstream=\myoutstream
% From now on, \show... commands are redirected to "infofile.tex".
%
% === actual tests ===
\showboxdepth10000
\showboxbreadth10000
%
\show\TeX
\setbox0=\hbox{A, B and C\showlists}\showbox0
\showthe\count0
{{\showgroups}}
\ifnum0=0 \showifs \fi
\showtokens{\A\B\C}
\ifx\showmode\undefined\else \showmode \fi
%
% === invalid usages ===
\showbox\relax
\showthe\ABC \relax
% => ! Undefined control sequence.
\showtokens A}\relax
% => ! Missing { inserted.
%
\showstream=-1
% -1 is never a open file and therefore restores
% normal \show... behavior.
\immediate\closeout\myoutstream
%
\end
```