### PR TITLE
pbibtex.ch: do not break at white_space after Jchar

### DIFF
--- a/source/texk/web2c/ptexdir/pbibtex.ch
+++ b/source/texk/web2c/ptexdir/pbibtex.ch
@@ -233,6 +233,25 @@ init_kanji;
 parse_arguments;
 @z
 
+% pBibTeX: do not break at |white_space| after Japanese characters
+@x "Break that line"
+while ((lex_class[out_buf[out_buf_ptr]] <> white_space) and
+                                        (out_buf_ptr >= min_print_line)) do
+    decr(out_buf_ptr);
+@y
+while (((lex_class[out_buf[out_buf_ptr]] <> white_space) or
+       (out_buf[out_buf_ptr-1] > 127)) and (out_buf_ptr >= min_print_line)) do
+    decr(out_buf_ptr);
+@z
+@x "Break that unbreakably long line"
+    if (lex_class[out_buf[out_buf_ptr]] <> white_space) then
+        incr(out_buf_ptr)
+@y
+    if (lex_class[out_buf[out_buf_ptr]] <> white_space) or
+      (out_buf[out_buf_ptr-1] > 127) then
+        incr(out_buf_ptr)
+@z
+
 @x Changes for JBibTeX by Shouichi Matsui [332]
 @!b_write : hash_loc;           {\.{write\$}}
 @!b_default : hash_loc;         {either \.{skip\$} or \.{default.type}}

--- a/source/texk/web2c/ptexdir/pbibtex.ch
+++ b/source/texk/web2c/ptexdir/pbibtex.ch
@@ -19,13 +19,20 @@
 % 10/30/92      last update for JBibTeX 0.31 for bug fix by Shouichi Matsui
 % 11/02/94      Version 0.32 for use with web2c 6.1, by Takafumi Sakurai
 %
+% 2002          Version 0.33 add kanji option by ASCII Corporation
+%
 % 2009          pTeXenc, pbibtex N. Tsuchimura
+% 2010          Version 0.99d of BibTeX for TeX Live
+%
+% 2022-02-08    Version 0.34 by H. Yamashita
+%               Do not break at white space after Japanese, to preserve spacing
+%               within BIB entry spacing to BBL for subsequent pTeX line-end operations
 
 @x [0] only print chnages
 \def\title{\BibTeX\ }
 @y
 \let\maybe=\iffalse
-\def\title{J\BibTeX\ 0.33 Changes for C Version \BibTeX\ }
+\def\title{J\BibTeX\ 0.34 Changes for C Version \BibTeX\ }
 @z
 
 @x
@@ -35,7 +42,7 @@
 @y
  \def\titlepage{F}
  \centerline{\:\titlefont The {\:\ttitlefont J\BibTeX} preprocessor}
- \vskip 15pt \centerline{(Version 0.33 based on C Version \BibTeX 0.99d---\today)} \vfill}
+ \vskip 15pt \centerline{(Version 0.99d-j0.34---\today)} \vfill}
 @z
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -46,7 +53,7 @@
 @d banner=='This is BibTeX, Version 0.99d' {printed when the program starts}
 @y
 @d my_name=='pbibtex'
-@d banner=='This is pBibTeX, Version 0.99d-j0.33'
+@d banner=='This is pBibTeX, Version 0.99d-j0.34'
   {printed when the program starts}
 @z
 

--- a/source/texk/web2c/uptexdir/upbibtex.ch
+++ b/source/texk/web2c/uptexdir/upbibtex.ch
@@ -1,9 +1,9 @@
 @x
 @d my_name=='pbibtex'
-@d banner=='This is pBibTeX, Version 0.99d-j0.33'
+@d banner=='This is pBibTeX, Version 0.99d-j0.34'
 @y
 @d my_name=='upbibtex'
-@d banner=='This is upBibTeX, Version 0.99d-j0.33-u1.28'
+@d banner=='This is upBibTeX, Version 0.99d-j0.34-u1.28'
 @z
 
 @x


### PR DESCRIPTION
https://github.com/texjporg/pbibtex-manual/issues/1 に対する修正案です。

* 半角スペースの前の文字が和文文字の場合は `max_print_line` を超えても行分割しない。
* ここで和文文字かどうかの判定は pBibTeX の `is.kanji.str$` に準拠し「バイトの最上位ビットが立っているかどうか」で判定する。

``` tex
%#!ptex
% https://github.com/texjporg/pbibtex-manual/issues/1
\input btxmac

\let\mbox = \hbox

\bibliography{\jobname}
\bibliographystyle{plain}

\nocite{*}

\end
```

``` bib
% for pbibtex
@misc{title-author-j,
  author = "作者不詳",
  title = "寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無 寿限無",
}

@misc{long-title-author-j,
  author = "どこかの誰か",
  title = "とてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとてもとても長い タイトル",
}

@misc{title-author,
  author = "Really Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Long Author",
  title = "Very very very very very very very very very very very very very very very very very very very very very very very very very very long title",
}

@misc{long-title-author,
  author = "Really Long Aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaauthor",
  title = "Titleeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee too",
}
```

### pBibTeX (2021)

<img width="802" alt="20220208-pbib2021" src="https://user-images.githubusercontent.com/9957466/152991683-e1e7f608-8e23-4673-9b13-6212f440ef28.png">

### pBibTeX 修正後

<img width="813" alt="20220208-pbib2022" src="https://user-images.githubusercontent.com/9957466/152991677-becd9f75-2c36-421b-bf06-cdc73b2f181a.png">

---

行分割を減らす方向の修正ですから，欧文の文献データベースには影響しませんし，pBibTeX → upBibTeX での修正も不要だと考えています。