### PR TITLE
issue:445 への対応

### DIFF
--- a/source/texk/mendexk/ChangeLog
+++ b/source/texk/mendexk/ChangeLog
@@ -1,3 +1,11 @@
+2022-09-01 Hironori Kitagawa <h_kitagawa2001@yahoo.co.jp>
+
+	* main.c:
+	Initialization of infile_enc_auto is moved to ptexenc.
+	Moved calls of KP_entry_filetype() (after checking options).
+	These changes prevent unwanted looking for texmf.cnf.
+	https://github.com/texjporg/tex-jp-build/pull/144
+
 2022-06-12  TANAKA Takuji  <ttk@t-lab.opal.ne.jp>
 
 	* main.c:

--- a/source/texk/mendexk/main.c
+++ b/source/texk/mendexk/main.c
@@ -40,22 +40,6 @@ int main(int argc, char **argv)
 			fprintf (stderr, "Ignoring bad kanji encoding \"%s\".\n", p);
 	}
 
-	p = kpse_var_value ("guess_input_kanji_encoding");
-	if (p) {
-		if (*p == '1' || *p == 'y' || *p == 't')
-			infile_enc_auto = 1;
-		free(p);
-	}
-
-	kp_ist.var_name = "INDEXSTYLE";
-	kp_ist.path = DEFAULT_INDEXSTYLES; /* default path. */
-	kp_ist.suffix = "ist";
-	KP_entry_filetype(&kp_ist);
-	kp_dict.var_name = "INDEXDICTIONARY";
-	kp_dict.path = DEFAULT_INDEXDICTS; /* default path */
-	kp_dict.suffix = "dict";
-	KP_entry_filetype(&kp_dict);
-
 /*   check options   */
 
 	for (i=1,j=k=0;i<argc && j<256;i++) {
@@ -229,6 +213,15 @@ int main(int argc, char **argv)
 		}
 	}
 	idxcount=j+fsti;
+
+	kp_ist.var_name = "INDEXSTYLE";
+	kp_ist.path = DEFAULT_INDEXSTYLES; /* default path. */
+	kp_ist.suffix = "ist";
+	KP_entry_filetype(&kp_ist);
+	kp_dict.var_name = "INDEXDICTIONARY";
+	kp_dict.path = DEFAULT_INDEXDICTS; /* default path */
+	kp_dict.suffix = "dict";
+	KP_entry_filetype(&kp_dict);
 
 /*   check option errors   */
 

--- a/source/texk/ptexenc/ChangeLog
+++ b/source/texk/ptexenc/ChangeLog
@@ -1,3 +1,9 @@
+2022-09-01  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
+
+	* ptexenc.c: Initialize infile_enc_auto only when this variable
+	is first used (input_line2).
+	https://github.com/texjporg/tex-jp-build/pull/144
+
 2022-06-12  TANAKA Takuji  <ttk@t-lab.opal.ne.jp>
 
 	* ptexenc.c, unicode.c, ptexenc/ptexenc.h, ptexenc/unicode.h:

--- a/source/texk/web2c/lib/texmfmp.c
+++ b/source/texk/web2c/lib/texmfmp.c
@@ -820,7 +820,6 @@ maininit (int ac, string *av)
 #if IS_pTeX
   kpse_set_program_name (argv[0], NULL);
   initkanji (); ptenc_ptex_mode(true);
-  infile_enc_auto = 2;
 #endif
 #if (defined(XeTeX) || defined(pdfTeX)) && defined(WIN32)
   kpse_set_program_name (argv[0], NULL);
@@ -864,17 +863,6 @@ maininit (int ac, string *av)
   parse_options (argc, argv);
 #else
   parse_options (ac, av);
-#endif
-
-#if IS_pTeX
-   if (infile_enc_auto == 2) {
-     p = kpse_var_value ("guess_input_kanji_encoding");
-     if (p) {
-       if (*p == '1' || *p == 'y' || *p == 't')  infile_enc_auto = 1;
-       free(p);
-     }
-   }
-   if (infile_enc_auto == 2) infile_enc_auto = 0;
 #endif
 
 #if IS_pTeX || ((defined(XeTeX) || defined(pdfTeX)) && defined(WIN32))

--- a/source/texk/web2c/lib/texmfmp.c
+++ b/source/texk/web2c/lib/texmfmp.c
@@ -789,6 +789,9 @@ void
 maininit (int ac, string *av)
 {
   string main_input_file;
+#if IS_pTeX
+  char *p;
+#endif
 #if (IS_upTeX || defined(XeTeX) || defined(pdfTeX)) && defined(WIN32)
   string enc;
 #endif
@@ -817,6 +820,7 @@ maininit (int ac, string *av)
 #if IS_pTeX
   kpse_set_program_name (argv[0], NULL);
   initkanji (); ptenc_ptex_mode(true);
+  infile_enc_auto = 2;
 #endif
 #if (defined(XeTeX) || defined(pdfTeX)) && defined(WIN32)
   kpse_set_program_name (argv[0], NULL);
@@ -860,6 +864,16 @@ maininit (int ac, string *av)
   parse_options (argc, argv);
 #else
   parse_options (ac, av);
+#endif
+
+#if IS_pTeX
+   if (infile_enc_auto == 2) {
+     p = kpse_var_value ("guess_input_kanji_encoding");
+     if (p) {
+       if (*p == '1' || *p == 'y' || *p == 't')  infile_enc_auto = 1;
+       free(p);
+     }
+   }
 #endif
 
 #if IS_pTeX || ((defined(XeTeX) || defined(pdfTeX)) && defined(WIN32))

--- a/source/texk/web2c/lib/texmfmp.c
+++ b/source/texk/web2c/lib/texmfmp.c
@@ -874,6 +874,7 @@ maininit (int ac, string *av)
        free(p);
      }
    }
+   if (infile_enc_auto == 2) infile_enc_auto = 0;
 #endif
 
 #if IS_pTeX || ((defined(XeTeX) || defined(pdfTeX)) && defined(WIN32))

--- a/source/texk/web2c/lib/texmfmp.c
+++ b/source/texk/web2c/lib/texmfmp.c
@@ -789,9 +789,6 @@ void
 maininit (int ac, string *av)
 {
   string main_input_file;
-#if IS_pTeX
-  char *p;
-#endif
 #if (IS_upTeX || defined(XeTeX) || defined(pdfTeX)) && defined(WIN32)
   string enc;
 #endif

--- a/source/texk/web2c/ptexdir/ChangeLog
+++ b/source/texk/web2c/ptexdir/ChangeLog
@@ -1,3 +1,9 @@
+2022-09-01  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
+
+	* kanji.c: Initialization of infile_enc_auto is moved to ptexenc.
+	This change prevents unwanted looking for texmf.cnf.
+	https://github.com/texjporg/tex-jp-build/pull/144
+
 2022-06-12  TANAKA Takuji  <ttk@t-lab.opal.ne.jp>
 
 	* kanji.[ch], pbibtex.ch:

--- a/source/texk/web2c/ptexdir/kanji.c
+++ b/source/texk/web2c/ptexdir/kanji.c
@@ -95,11 +95,4 @@ void init_default_kanji (const_string file_str, const_string internal_str)
         if (!set_enc_string (p, NULL))
             fprintf (stderr, "Ignoring bad kanji encoding \"%s\".\n", p);
     }
-
-    p = kpse_var_value ("guess_input_kanji_encoding");
-    if (p) {
-        if (*p == '1' || *p == 'y' || *p == 't')
-            infile_enc_auto = 1;
-        free(p);
-    }
 }

--- a/source/texk/web2c/uptexdir/ChangeLog
+++ b/source/texk/web2c/uptexdir/ChangeLog
@@ -1,3 +1,9 @@
+2022-09-01  Hironori Kitagawa  <h_kitagawa2001@yahoo.co.jp>
+
+	* kanji.c: Initialization of infile_enc_auto is moved to ptexenc.
+	This change prevents unwanted looking for texmf.cnf.
+	https://github.com/texjporg/tex-jp-build/pull/144
+
 2022-07-23  TANAKA Takuji  <ttk@t-lab.opal.ne.jp>
 
 	* uptex-m.ch, upbibtex.ch, updvitype.ch, uppltotf.ch, uptftopl.ch,

--- a/source/texk/web2c/uptexdir/kanji.c
+++ b/source/texk/web2c/uptexdir/kanji.c
@@ -519,13 +519,6 @@ void init_default_kanji (const_string file_str, const_string internal_str)
         if (!set_enc_string (p, NULL))
             fprintf (stderr, "Ignoring bad kanji encoding \"%s\".\n", p);
     }
-
-    p = kpse_var_value ("guess_input_kanji_encoding");
-    if (p) {
-        if (*p == '1' || *p == 'y' || *p == 't')
-            infile_enc_auto = 1;
-        free(p);
-    }
 }
 
 void init_default_kanji_select(void)


### PR DESCRIPTION
issue:445（`parse_options()` の前に `kpse_var_value()` が実行されるので，`ptex --version` など本来は texmf.cnf を参照する必要がないはずの状況でも texmf.cnf を探しにいってしまう）への対応です．

infile_enc_auto が `parse_options()` のあとに定まるようにしましたが，これで問題ないでしょうか．