### PR TITLE
uptex-m.ch: support \kchar in math

### DIFF
--- a/source/texk/web2c/uptexdir/ChangeLog
+++ b/source/texk/web2c/uptexdir/ChangeLog
@@ -1,3 +1,10 @@
+2023-09-03  Hironobu Yamashita  <h.y.acetaminophen@gmail.com>
+
+	* uptex-m.ch: Proper support for \kchar in math mode.
+	https://github.com/texjporg/tex-jp-build/pull/159
+	* kanji.c: Check character code range < 2^24.
+	https://github.com/texjporg/tex-jp-build/issues/160
+
 2023-08-20  TANAKA Takuji  <ttk@t-lab.opal.ne.jp>
 
 	* am/uptex.am, {gkhuge,newjfm,nissya,ptriptest,

--- a/source/texk/web2c/uptexdir/kanji.c
+++ b/source/texk/web2c/uptexdir/kanji.c
@@ -16,7 +16,7 @@ boolean check_kanji (integer c)
 {
     if (c >= CS_TOKEN_FLAG) return false;
     else if (!(XXHi(c)>=KCAT_KANJI && XXHi(c)<=KCAT_HANGUL)) return false;
-    else return is_char_kanji(c);
+    else return is_char_kanji(c & CJK_TOKEN_FLAG);
 }
 
 boolean is_char_ascii(integer c)
@@ -27,7 +27,7 @@ boolean is_char_ascii(integer c)
 boolean is_char_kanji(integer c)
 {
     if (is_internalUPTEX()) 
-        return (c >= 0);
+        return ((c >= 0)&&(c<CJK_CHAR_LIMIT));
     else
         return iskanji1(Hi(c)) && iskanji2(Lo(c));
 }

--- a/source/texk/web2c/uptexdir/uptex-m.ch
+++ b/source/texk/web2c/uptexdir/uptex-m.ch
@@ -670,7 +670,6 @@ while k<pool_ptr do
 @z
 
 @x
-
 @d ptex_revision_code=14 {command code for \.{\\ptexrevision}}
 @d ptex_convert_codes=15 {end of \pTeX's command codes}
 @y
@@ -783,22 +782,6 @@ if (cur_cmd>=kanji)and(cur_cmd<=hangul) then
 @z
 
 @x
-loop@+  begin get_x_token;
-  reswitch: case cur_cmd of
-  letter,other_char,char_given:@<Append a new letter or hyphen@>;
-  char_num: begin scan_char_num; cur_chr:=cur_val; cur_cmd:=char_given;
-    goto reswitch;
-    end;
-@y
-loop@+  begin get_x_token;
-  reswitch: case cur_cmd of
-  letter,other_char,char_given,kchar_given:@<Append a new letter or hyphen@>;
-  char_num,kchar_num: begin scan_char_num; cur_chr:=cur_val; cur_cmd:=char_given;
-    goto reswitch;
-    end;
-@z
-
-@x
 hmode+kanji,hmode+kana,hmode+other_kchar: goto main_loop_j;
 hmode+char_given:
   if is_char_ascii(cur_chr) then goto main_loop else goto main_loop_j;
@@ -811,11 +794,11 @@ hmode+no_boundary: begin get_x_token;
    (cur_cmd=char_given)or(cur_cmd=char_num) then cancel_boundary:=true;
 @y
 hmode+kanji,hmode+kana,hmode+other_kchar,hmode+hangul: goto main_loop_j;
-hmode+kchar_given:
-  begin cur_cmd:=kcat_code(kcatcodekey(cur_chr)); goto main_loop_j; end;
 hmode+char_given:
   if check_echar_range(cur_chr) then goto main_loop
   else begin cur_cmd:=kcat_code(kcatcodekey(cur_chr)); goto main_loop_j; end;
+hmode+kchar_given:
+  begin cur_cmd:=kcat_code(kcatcodekey(cur_chr)); goto main_loop_j; end;
 hmode+char_num: begin scan_char_num; cur_chr:=cur_val;
   if check_echar_range(cur_chr) then goto main_loop
   else begin cur_cmd:=kcat_code(kcatcodekey(cur_chr)); goto main_loop_j; end;
@@ -874,6 +857,9 @@ if cur_cmd=char_given then
   begin if check_echar_range(cur_chr) then goto main_loop_lookahead+1
   else begin cur_cmd:=kcat_code(kcatcodekey(cur_chr)); @<goto |main_lig_loop|@>; end;
   end;
+if cur_cmd=kchar_given then
+  begin cur_chr:=cur_chr mod max_cjk_val;
+  cur_cmd:=kcat_code(kcatcodekey(cur_chr)); @<goto |main_lig_loop|@>; end;
 if cur_cmd=char_num then
   begin scan_char_num; cur_chr:=cur_val;
   if check_echar_range(cur_chr) then goto main_loop_lookahead+1
@@ -995,11 +981,20 @@ letter,other_char,char_given:
 @x
     KANJI(cx):=cur_chr;
 kanji,kana,other_kchar: cx:=cur_chr;
+char_num: begin scan_char_num; cur_chr:=cur_val; cur_cmd:=char_given;
+  goto reswitch;
+  end;
 @y
     KANJI(cx):=cur_chr;
+kanji,kana,other_kchar,hangul: cx:=cur_chr;
 kchar_given:
   KANJI(cx):=cur_chr;
-kanji,kana,other_kchar,hangul: cx:=cur_chr;
+char_num: begin scan_char_num; cur_chr:=cur_val; cur_cmd:=char_given;
+  goto reswitch;
+  end;
+kchar_num: begin scan_char_num; cur_chr:=cur_val; cur_cmd:=kchar_given;
+  goto reswitch;
+  end;
 @z
 
 @x


### PR DESCRIPTION
`kchar_num` の考慮漏れにより，最後の行でエラーが出ることに気づきました。

``` tex
%#!uptex
\chardef\X="3042    $\left[a_\X\right]$
\def\W{\char"3042}  $\left[a_\W\right]$
\kchardef\X="3042   $\left[a_\X\right]$
\def\W{\kchar"3042} $\left[a_\W\right]$ % => ! Missing { inserted. !?
\bye
```

uptex-math-kchar ブランチで直しています。