### PR TITLE
dvipdfm-x: fix issue when including the same image multiple times

### DIFF
--- a/source/texk/dvipdfm-x/pdfximage.c
+++ b/source/texk/dvipdfm-x/pdfximage.c
@@ -396,6 +396,8 @@ load_image (const char *ident, const char *filename, const char *fullname, int f
 int utf8name_failed = 0;
 #endif /* WIN32 */
 
+#define dpx_streq(a, b) ((a) == (b) || (a) && (b) && strcmp(a, b) == 0)
+
 int
 pdf_ximage_load_image (const char *ident, const char *filename, load_options options)
 {
@@ -408,20 +410,21 @@ pdf_ximage_load_image (const char *ident, const char *filename, load_options opt
 
   for (i = 0; i < ic->count; i++) {
     I = &ic->ximages[i];
-    if (I->filename && !strcmp(filename, I->filename)) {
-      id = i;
-      break;
-    }
-  }
-  if (id >= 0) {
-    if (I->attr.page_no == options.page_no &&
-        (I->attr.page_name && options.page_name &&
-         strcmp(I->attr.page_name, options.page_name) == 0) &&
-        !pdf_compare_object(I->attr.dict, options.dict) && /* ????? */
-        I->attr.bbox_type == options.bbox_type) {
-      return id;
-    }
+    if (I->filename == NULL || strcmp(filename, I->filename) != 0)
+      continue;
+    id = i;
     f = I->fullname;
+
+    if (I->attr.page_no != options.page_no)
+      continue;
+    if (!dpx_streq(I->attr.page_name, options.page_name))
+      continue;
+    if (pdf_compare_object(I->attr.dict, options.dict) != 0) /* ????? */
+      continue;
+    if (I->attr.bbox_type != options.bbox_type)
+      continue;
+
+    return id;
   }
   if (f) {
     /* we already have converted this file; f is the temporary file name */


### PR DESCRIPTION
TeX フォーラムの「[dvipdfmxのバージョンでPDFファイルサイズが肥大化する](https://okumuralab.org/tex/mod/forum/discuss.php?d=3743)」に対する修正案です。

同じ画像を複数回挿入したときに TL2023 では最初の 1 つだけ挿入してそのオブジェクトを共有していたのが TL2024 では別々のオブジェクトとしてそれぞれ挿入されるようになってしまっているようです。

[r70147](https://www.tug.org/svn/texlive?revision=70147&view=revision) の `pdf:image` での名前によるページ選択機能の追加と [r70406](https://www.tug.org/svn/texlive?revision=70406&view=revision) でのその修正の影響のようです。

またこれとは別に最初に画像の 1 ページ目を挿入したあと同じ画像ファイルの 2 ページ目を複数回挿入すると挿入した回数分別オブジェクトとして挿入されていたので、こちらも修正してみました。（こちらはTL2023以前から）