### PR TITLE
[(up)mendex] Remove the 2nd argument of idxread()

### DIFF
--- a/source/texk/mendexk/fread.c
+++ b/source/texk/mendexk/fread.c
@@ -13,7 +13,7 @@ static void chkpageattr(struct page *p);
 static void copy_multibyte_char(char *buff1, char *buff2, int *i, int *j);
 
 /*   read idx file   */
-int idxread(char *filename, int start)
+int idxread(char *filename)
 {
 	int i,j,k,l,m,n,cc,indent,wflg,flg=0,bflg=0,nest,esc,quo,eflg=0,pacc,preject;
 	char buff[BUFSIZE],wbuff[BUFSIZE],estr[256],table[BUFSIZE],*tmp1,*tmp2;
@@ -49,7 +49,7 @@ int idxread(char *filename, int start)
 		verb_printf(efp,"Scanning input file %s.",filename);
 	}
 
-	for (i=start,n=1;;i++,n++) {
+	for (i=lines,n=1;;i++,n++) {
 		if (!(i%100))
 			ind=(struct index *)xrealloc(ind,sizeof(struct index)*(i+100));
 LOOP:

--- a/source/texk/mendexk/main.c
+++ b/source/texk/mendexk/main.c
@@ -316,10 +316,10 @@ int main(int argc, char **argv)
 	ind=xmalloc(sizeof(struct index));
 
 	for (i=0;i<idxcount-fsti;i++) {
-		ecount+=idxread(idxfile[i],lines);
+		ecount+=idxread(idxfile[i]);
 	}
 	if (fsti==1) {
-		ecount+=idxread(NULL,lines);
+		ecount+=idxread(NULL);
 	}
 	verb_printf(efp,"%d entries accepted, %d rejected.\n",acc,reject);
 

--- a/source/texk/mendexk/mendex.h
+++ b/source/texk/mendexk/mendex.h
@@ -52,7 +52,7 @@ void styread(const char *filename);
 
 /* fread.c */
 char *mfgets(char *buf, int size, FILE *fp);
-int idxread(char *filename, int start);
+int idxread(char *filename);
 
 /* fwrite.c */
 int fprintf2   (FILE *fp, const char *format, ...);

--- a/source/texk/upmendex/fread.c
+++ b/source/texk/upmendex/fread.c
@@ -12,7 +12,7 @@ static void chkpageattr(struct page *p);
 static void copy_multibyte_char(char *buff1, char *buff2, int *i, int *j);
 
 /*   read idx file   */
-int idxread(char *filename, int start)
+int idxread(char *filename)
 {
 	int i,j,k,l,m,n,cc,indent,wflg,flg=0,bflg=0,nest,esc,quo,eflg=0,pacc,preject;
 	char buff[BUFSIZE],wbuff[BUFSIZE],estr[256],table[BUFSIZE];
@@ -49,7 +49,7 @@ int idxread(char *filename, int start)
 		verb_printf(efp,"Scanning input file %s.",filename);
 	}
 
-	for (i=start,n=1;;i++,n++) {
+	for (i=lines,n=1;;i++,n++) {
 		if (!(i%100))
 			ind=(struct index *)xrealloc(ind,sizeof(struct index)*(i+100));
 LOOP:

--- a/source/texk/upmendex/main.c
+++ b/source/texk/upmendex/main.c
@@ -303,10 +303,10 @@ int main(int argc, char **argv)
 	ind=xmalloc(sizeof(struct index));
 
 	for (i=0;i<idxcount-fsti;i++) {
-		ecount+=idxread(idxfile[i],lines);
+		ecount+=idxread(idxfile[i]);
 	}
 	if (fsti==1) {
-		ecount+=idxread(NULL,lines);
+		ecount+=idxread(NULL);
 	}
 	verb_printf(efp,"%d entries accepted, %d rejected.\n",acc,reject);
 

--- a/source/texk/upmendex/mendex.h
+++ b/source/texk/upmendex/mendex.h
@@ -120,7 +120,7 @@ void styread(const char *filename);
 void set_icu_attributes(void);
 
 /* fread.c */
-int idxread(char *filename, int start);
+int idxread(char *filename);
 int multibyte_to_widechar(UChar *wcstr, int32_t size, char *mbstr);
 int widechar_to_multibyte(char *mbstr, int32_t size, UChar *wcstr);
 


### PR DESCRIPTION
### `fread.c` にある `int idxread(char *filename, int start)` の第二引数 `start` は紛らわしく，実は不要．

- `idxread(char *filename, int start)` が呼ばれるのは，`main()` からだけです．
- いずれの呼び出しでも，二番目の引数には，グローバル変数である `lines` の値が渡されます．
- `idxread()` の中で，二番目の引数として渡された `start` が使われるのは，（まだ `lines` が変更を受けていないところで） for 文の初期化部分において `i=start` として一度使われるのみです．
- したがって，for 文の初期化部分においては `i=lines` とすれば十分です．

これは，TeX Forum で指摘させていただいた件です（そこに二つあるパッチのうち最初のものに相当します）．
https://okumuralab.org/tex/mod/forum/discuss.php?d=3976#p24772

この修正は，実行結果には全く影響を与えません．
私以外にもこのコードに惑わされた方がいらっしゃるようなので，修正を提案いたします．
今後新しくコードを読まれるかたのためにも採用されることを願います．

いかがでしょうか．
